### PR TITLE
Fix the SparkLine

### DIFF
--- a/src/Sparks.jsx
+++ b/src/Sparks.jsx
@@ -16,7 +16,7 @@ export function Sparks({ count, colors, radius = 10 }) {
     const material = useRef();
     useEffect(() => {
       console.log(material.current.uniforms.dashOffset.value)
-      material.current.uniforms.dashOffset.value -= speed * frame;
+      material.current.uniforms.dashOffset.value = -speed * frame;
       advance();
     }, [frame, speed]);
 

--- a/src/Sparks.jsx
+++ b/src/Sparks.jsx
@@ -16,7 +16,7 @@ export function Sparks({ count, colors, radius = 10 }) {
     const material = useRef();
     useEffect(() => {
       console.log(material.current.uniforms.dashOffset.value)
-      material.current.uniforms.dashOffset.value -= speed;
+      material.current.uniforms.dashOffset.value -= speed * frame;
       advance();
     }, [frame, speed]);
 


### PR DESCRIPTION
Explanation:

In Remotion, every value needs to be calculated based on the current time.
It is not valid to calculate a new value based on the one that was used in the previously rendered frame.

While it requires some refactoring of code, the benefit is that rendering is multithread-safe and that scrubbing through the timeline always results in the right frame, even when you go backwards.

https://user-images.githubusercontent.com/1629785/212466892-43d35357-f488-46f7-a7fc-b37db7e29d15.mov

